### PR TITLE
fix: resolve all astro check type errors and warnings

### DIFF
--- a/src/components/blog/DiwanList.astro
+++ b/src/components/blog/DiwanList.astro
@@ -2,7 +2,7 @@
 import type { Locale } from '@/i18n';
 import type { CollectionEntry } from 'astro:content';
 import { useTranslations } from '@/i18n/ui';
-import { formatDate, formatNumber } from '@/utils/date';
+import { formatDate } from '@/utils/date';
 import { readingTime } from '@/utils/reading-time';
 import { getSlugFromId } from '@/utils/content';
 import PostThumbnail from '@/components/ui/PostThumbnail.astro';
@@ -32,7 +32,6 @@ const t = useTranslations(locale);
     {posts.map((post, i) => {
       const slug = getSlugFromId(post.id);
       const minutes = readingTime(post.body ?? '', locale);
-      const num = formatNumber(startNum + i, locale).padStart(2, '0');
       return (
         <li class="diwan__item">
           <a href={`/${locale}/blog/${slug}/`} class="diwan__thumb-link">

--- a/src/components/blog/ShareButtons.astro
+++ b/src/components/blog/ShareButtons.astro
@@ -67,7 +67,7 @@ const t = useTranslations(locale);
   .share__btn:hover { border-color: var(--ink); color: var(--ink); }
 </style>
 
-<script define:vars={{ title }}>
+<script is:inline define:vars={{ title }}>
   const url = window.location.href;
 
   document.querySelector('[data-action="copy"]')?.addEventListener('click', async (e) => {

--- a/src/components/global/SearchDialog.astro
+++ b/src/components/global/SearchDialog.astro
@@ -164,8 +164,6 @@ const t = useTranslations(locale);
     const closeBtn = document.getElementById('search-close');
     const mount = document.getElementById('pagefind-mount');
     let initialized = false;
-    let pagefindUI: any = null;
-
     async function initPagefind() {
       if (initialized || !mount) return;
       initialized = true;
@@ -178,13 +176,14 @@ const t = useTranslations(locale);
         document.head.appendChild(cssLink);
 
         // Dynamically import Pagefind UI
+        // @ts-expect-error pagefind generated at build time
         const module = await import(/* @vite-ignore */ '/pagefind/pagefind-ui.js');
         const PagefindUI = module.default;
         
         // Clear loading state
         mount.innerHTML = '';
         
-        pagefindUI = new PagefindUI({
+        new PagefindUI({
           element: '#pagefind-mount',
           showSubResults: true,
           showImages: false,

--- a/src/pages/ar/blog/[...slug].astro
+++ b/src/pages/ar/blog/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import BlogLayout from '@/layouts/BlogLayout.astro';
-import { render } from 'astro:content';
+import { render, type CollectionEntry } from 'astro:content';
 import { getPostsByLocale, getRecentPosts, getSlugFromId } from '@/utils/content';
 import { readingTime } from '@/utils/reading-time';
 import type { GetStaticPaths } from 'astro';
@@ -14,7 +14,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }));
 };
 
-const { post } = Astro.props;
+const { post } = Astro.props as { post: CollectionEntry<'blog'> };
 const locale = 'ar';
 const { Content, headings } = await render(post);
 const related = await getRecentPosts(locale, post.id, 3);

--- a/src/pages/ar/search.astro
+++ b/src/pages/ar/search.astro
@@ -90,6 +90,7 @@ const locale = 'ar';
     if (!mount) return;
     
     try {
+      // @ts-expect-error pagefind generated at build time
       const module = await import(/* @vite-ignore */ '/pagefind/pagefind-ui.js');
       const PagefindUI = module.default;
       

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import BlogLayout from '@/layouts/BlogLayout.astro';
-import { render } from 'astro:content';
+import { render, type CollectionEntry } from 'astro:content';
 import { getPostsByLocale, getRecentPosts, getSlugFromId } from '@/utils/content';
 import { readingTime } from '@/utils/reading-time';
 import type { GetStaticPaths } from 'astro';
@@ -14,7 +14,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }));
 };
 
-const { post } = Astro.props;
+const { post } = Astro.props as { post: CollectionEntry<'blog'> };
 const locale = 'en';
 const { Content, headings } = await render(post);
 const related = await getRecentPosts(locale, post.id, 3);

--- a/src/pages/en/search.astro
+++ b/src/pages/en/search.astro
@@ -91,6 +91,7 @@ const locale = 'en';
     if (!mount) return;
     
     try {
+      // @ts-expect-error pagefind generated at build time
       const module = await import(/* @vite-ignore */ '/pagefind/pagefind-ui.js');
       const PagefindUI = module.default;
       

--- a/src/pages/zh/blog/[...slug].astro
+++ b/src/pages/zh/blog/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import BlogLayout from '@/layouts/BlogLayout.astro';
-import { render } from 'astro:content';
+import { render, type CollectionEntry } from 'astro:content';
 import { getPostsByLocale, getRecentPosts, getSlugFromId } from '@/utils/content';
 import { readingTime } from '@/utils/reading-time';
 import type { GetStaticPaths } from 'astro';
@@ -14,7 +14,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }));
 };
 
-const { post } = Astro.props;
+const { post } = Astro.props as { post: CollectionEntry<'blog'> };
 const locale = 'zh';
 const { Content, headings } = await render(post);
 const related = await getRecentPosts(locale, post.id, 3);

--- a/src/pages/zh/search.astro
+++ b/src/pages/zh/search.astro
@@ -90,6 +90,7 @@ const locale = 'zh';
     if (!mount) return;
     
     try {
+      // @ts-expect-error pagefind generated at build time
       const module = await import(/* @vite-ignore */ '/pagefind/pagefind-ui.js');
       const PagefindUI = module.default;
       


### PR DESCRIPTION
## Summary
Fixes all 16 type errors and 3 warnings reported by `astro check`.

## Changes
- **Blog post pages** (`[...slug].astro` × 3 locales): typed `Astro.props` as `{ post: CollectionEntry<'blog'> }` to resolve `unknown` type errors on `post`
- **Search pages** (`search.astro` × 3 locales + `SearchDialog.astro`): added `@ts-expect-error` for pagefind dynamic imports (module generated at build time, not available during type checking)
- **DiwanList.astro**: removed unused `num` variable and `formatNumber` import
- **SearchDialog.astro**: removed unused `pagefindUI` variable
- **ShareButtons.astro**: added explicit `is:inline` directive to `<script>` tag

## Verification
- [x] `npm run check` — 0 errors, 0 warnings, 0 hints
- [x] `npm run build` — 28 pages built successfully across ar/en/zh
- [x] Pagefind indexed 3212 words across 3 languages